### PR TITLE
Add <cstdint> to vector_ref.h for GCC 13+/Debian 13 build

### DIFF
--- a/libdevcore/vector_ref.h
+++ b/libdevcore/vector_ref.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstring>
+#include <cstdint>
 #include <cassert>
 #include <type_traits>
 #include <vector>


### PR DESCRIPTION
## Problem
On GCC 13/14 (e.g. Debian 13 "trixie") building a project that embeds this library fails with:

```
libdevcore/vector_ref.h:77: error: 'uint8_t' was not declared in this scope
```

`vector_ref.h` uses `uint8_t` but only received it transitively from other standard headers. Modern libstdc++ (GCC 13+) no longer pulls `<cstdint>` in indirectly, so the type is undefined and a cascade of cast/parse errors follows.

## Fix
Include `<cstdint>` explicitly in `vector_ref.h`.

Needed to build VIPSTARCOIN on Debian 13 (GCC 14).